### PR TITLE
Don't look up array index before we know it was within bounds

### DIFF
--- a/Data/PerfectHash.hs
+++ b/Data/PerfectHash.hs
@@ -47,5 +47,5 @@ lookup !bs !ph  = guard check >> return e
     where index = {-# SCC "hash_only" #-} unsafePerformIO $ CMPH.hash (computedHash ph) bs
           (!low, !high) = bounds arr
           !arr = store ph
-          !e = {-# SCC array_lookup #-} arr ! index
+          e = {-# SCC array_lookup #-} arr ! index
           !check = {-# SCC "check" #-} low <= index && high >= index

--- a/perfecthash.cabal
+++ b/perfecthash.cabal
@@ -24,7 +24,7 @@ Library
 --        extra-libraries: cmph
         build-depends:  base >=4.5 && <5.2,
                         containers,
-                        cmph,
+                        cmph >=0.0.2 && <0.1,
                         bytestring,
                         array,
                         time
@@ -36,7 +36,7 @@ test-suite cmph-test
   hs-source-dirs:      test
   main-is:             Main.hs
   other-modules:       Data.PerfectHashSpec
-  build-depends:       cmph
+  build-depends:       cmph >=0.0.2 && <0.1
                      , base
                      , hspec
                      , QuickCheck
@@ -58,6 +58,7 @@ Benchmark bench-foo
                   , perfecthash
                   , unordered-containers
                   , deepseq
+
 source-repository head
   type: git
   location: http://github.com/mwotton/PerfectHash.git

--- a/perfecthash.cabal
+++ b/perfecthash.cabal
@@ -1,19 +1,19 @@
 Name:           perfecthash
 Version:        0.2.0
 Cabal-Version:  >= 1.10
-License:	BSD3
+License:        BSD3
 License-File:   LICENSE
 Build-Type:     Simple
-Author:		Mark Wotton <mwotton@gmail.com>
-Maintainer:	Mark Wotton <mwotton@gmail.com>
-Category:	Data, Data Structures
-Stability:	Experimental
+Author:         Mark Wotton <mwotton@gmail.com>
+Maintainer:     Mark Wotton <mwotton@gmail.com>
+Category:       Data, Data Structures
+Stability:      Experimental
 extra-source-files:  README, TODO
-bug-reports:	mailto:mwotton@gmail.com
-Synopsis:	A perfect hashing library for mapping bytestrings to values.
+bug-reports:    mailto:mwotton@gmail.com
+Synopsis:       A perfect hashing library for mapping bytestrings to values.
 Description:    A perfect hashing library for mapping bytestrings to values.
-		Insertion is not supported (by design): Only fromList
-		and lookup operations are supported.
+                Insertion is not supported (by design): Only fromList
+                and lookup operations are supported.
 
                 CI at https://travis-ci.org/mwotton/PerfectHash
 Library
@@ -45,6 +45,7 @@ test-suite cmph-test
                      , containers
 
 Benchmark bench-foo
+    default-language: Haskell2010
     type:       exitcode-stdio-1.0
     main-is:        Main.hs
     hs-source-dirs: benchmark


### PR DESCRIPTION
Also depend on cmph >= 0.0.2 so it builds